### PR TITLE
Type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.3",
   "description": "A polyfill for the asynchronous clipboard API",
   "main": "build/clipboard-polyfill.js",
+  "types": "build/clipboard-polyfill.d.ts",
   "dependencies": {
     "es6-promise": "4.1.1"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "sourceMap": true,
     "strictNullChecks": true,
     "lib": ["es6", "DOM"],
-    "target": "es5"
+    "target": "es5",
+    "declaration": true
   }
 }


### PR DESCRIPTION
Addresses #61. Type declaration files will now be generated during `make` and users of the module will no longer need a separately maintained `@types` package.