### PR TITLE
Only publish "build" (and NPM defaults)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-# Including this file prevents `npm`/`yarn` from excluding everything in
-# `.gitignore, and only ignores files specified here.
-/node_modules
-
-# Workaround for https://github.com/lgarron/clipboard-polyfill/issues/90
-/.git

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/lgarron/clipboard-polyfill/issues"
-  }
+  },
+  "files": ["/build"]
 }


### PR DESCRIPTION
Lets not publish all the other fluff files. There is no reason for anyone to download them when doing a `yarn add`. 

Files that will no longer be published:

![image](https://user-images.githubusercontent.com/4019718/52536807-9b2be900-2d5f-11e9-8a9b-bc126a39c905.png)

```sh
$ npm publish --dry-run
npm notice
npm notice package: clipboard-polyfill@2.7.0
npm notice === Tarball Contents ===
npm notice 932B   package.json
npm notice 1.1kB  LICENSE.md
npm notice 9.3kB  README.md
npm notice 896B   build/clipboard-polyfill.d.ts
npm notice 10.4kB build/clipboard-polyfill.js
npm notice 6.3kB  build/clipboard-polyfill.js.map
npm notice 85B    build/clipboard-polyfill.promise.d.ts
npm notice 24.1kB build/clipboard-polyfill.promise.js
npm notice 173B   build/clipboard-polyfill.promise.js.map
npm notice 250B   build/DT.d.ts
npm notice 700B   build/DT.js
npm notice 1.0kB  build/DT.js.map
npm notice === Tarball Details ===
npm notice name:          clipboard-polyfill
npm notice version:       2.7.0
npm notice package size:  14.3 kB
npm notice unpacked size: 55.2 kB
npm notice shasum:        5325c2e79a72eafed85776b54628d3350b6ebb36
npm notice integrity:     sha512-CNMwBImViADbc[...]U/rVg/uM8tFkg==
npm notice total files:   12
npm notice
+ clipboard-polyfill@2.7.0
```