### PR TITLE
Fixed infinite recursion bug

### DIFF
--- a/src/clipboard-polyfill.ts
+++ b/src/clipboard-polyfill.ts
@@ -55,10 +55,12 @@ export async function write(data: DT): Promise<void> {
   throw new Error("Copy command failed.");
 }
 
+const cachedClipboard = navigator.clipboard;
+
 export async function writeText(s: string): Promise<void> {
-  if (navigator.clipboard && navigator.clipboard.writeText) {
+  if (cachedClipboard && cachedClipboard.writeText && cachedClipboard !== this) {
     debugLog("Using `navigator.clipboard.writeText()`.");
-    return navigator.clipboard.writeText(s);
+    return cachedClipboard.writeText(s);
   }
   return write(DTFromText(s));
 }
@@ -68,9 +70,9 @@ export async function read(): Promise<DT> {
 }
 
 export async function readText(): Promise<string> {
-  if (navigator.clipboard && navigator.clipboard.readText) {
+  if (cachedClipboard && cachedClipboard.readText && cachedClipboard !== this) {
     debugLog("Using `navigator.clipboard.readText()`.");
-    return navigator.clipboard.readText();
+    return cachedClipboard.readText();
   }
   if (seemToBeInIE()) {
     debugLog("Reading text using IE strategy.");


### PR DESCRIPTION
Attempting to assign the imported module to `navigator.clipboard` and then using the `writeText` or `readText` methods would recurse infinitely, resulting in a stack overflow.

The reason for this was the faulty attempt to read from `navigator.clipboard` if it's available, regardless of what that binding actually references.

This commit forbids the use of `navigator.clipboard` if it contains a reference to the polyfill itself.