### PR TITLE
Fix conditional exports in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,12 +72,12 @@
     },
     "./overwrite-globals": {
       "require": "./dist/overwrite-globals/clipboard-polyfill.overwrite-globals.js",
-      "module": "./dist/overwrite-globals/clipboard-polyfill.overwrite-globals.esm.js",
+      "import": "./dist/overwrite-globals/clipboard-polyfill.overwrite-globals.esm.js",
       "types": "./dist/overwrite-globals/targets/overwrite-globals.d.ts"
     },
     "./text": {
       "require": "./dist/text/clipboard-polyfill.text.js",
-      "module": "./dist/text/clipboard-polyfill.text.esm.js",
+      "import": "./dist/text/clipboard-polyfill.text.esm.js",
       "types": "./dist/text/targets/text.d.ts"
     }
   }


### PR DESCRIPTION
This fixes an error I encountered in a dependent package ([`pmndrs/leva`](https://github.com/pmndrs/leva)) while building it with a barebones `esbuild` config. According to the NodeJS docs, only `"import",` `"require"`, `"node"` and `"default"` are valid keys, `"module"` is not:

https://nodejs.org/api/packages.html#packages_conditional_exports

(Not sure if `"types"` are considered by TS or not, so I left those in. Also shout-outs to @n1ru4l who correctly identified this problem 🥇 )