### PR TITLE
FileReader.readAsText: Argument 1 is not an object error #164

### DIFF
--- a/src/clipboard-polyfill/promise/promise-compat.ts
+++ b/src/clipboard-polyfill/promise/promise-compat.ts
@@ -5,7 +5,7 @@ export function promiseRecordMap<T>(
   f: (key: string) => Promise<T>,
 ): Promise<Record<string, T>> {
   var promiseList: Promise<T>[] = [];
-  for (var i in keys) {
+  for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
     promiseList.push(f(key));
   }


### PR DESCRIPTION
The for in loop structure in the #promiseRecordMap method returns another key called 'pushArray' in addition to the list of keys, which is why the problem occurs.