### PR TITLE
Define exports entrypoints using default

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   "types": "./dist/types/entries/es6/clipboard-polyfill.es6.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/es6/clipboard-polyfill.es6.js",
+      "default": "./dist/es6/clipboard-polyfill.es6.js",
       "types": "./dist/types/entries/es6/clipboard-polyfill.es6.d.ts"
     },
     "./overwrite-globals": {
-      "import": "./dist/es5/overwrite-globals/clipboard-polyfill.overwrite-globals.es5.js",
+      "default": "./dist/es5/overwrite-globals/clipboard-polyfill.overwrite-globals.es5.js",
       "types": "./dist/types/entries/es5/overwrite-globals.d.ts"
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
   "types": "./dist/types/entries/es6/clipboard-polyfill.es6.d.ts",
   "exports": {
     ".": {
-      "default": "./dist/es6/clipboard-polyfill.es6.js",
-      "types": "./dist/types/entries/es6/clipboard-polyfill.es6.d.ts"
+      "types": "./dist/types/entries/es6/clipboard-polyfill.es6.d.ts",
+      "default": "./dist/es6/clipboard-polyfill.es6.js"
     },
     "./overwrite-globals": {
-      "default": "./dist/es5/overwrite-globals/clipboard-polyfill.overwrite-globals.es5.js",
-      "types": "./dist/types/entries/es5/overwrite-globals.d.ts"
+      "types": "./dist/types/entries/es5/overwrite-globals.d.ts",
+      "default": "./dist/es5/overwrite-globals/clipboard-polyfill.overwrite-globals.es5.js"
     }
   }
 }


### PR DESCRIPTION
Updates the `package.json` `exports` to set default entrypoints using `default` instead of `import`.

Reference documentation: https://nodejs.org/api/packages.html#conditional-exports

`"import"` limits use to ESM environments. As of Node.js v22 (current LTS), there's now [improved support to allow CommonJS to use ESM-only projects](https://nodejs.org/en/blog/announcements/v22-release-announce#support-requireing-synchronous-esm-graphs) like this one. 

Without these changes, a CommonJS project trying to import this library will encounter the following error:

```
 Exception during run: Error: No "exports" main defined in /Code/my-project/node_modules/clipboard-polyfill/package.json
```

(This is actually a long-delayed follow-up to https://github.com/lgarron/clipboard-polyfill/pull/148#issuecomment-1373749500, where our project is _still_ CommonJS, but we'd love to be able to upgrade with this new capability in Node.js v22)